### PR TITLE
Feature: Add option to specify RPC endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.13
 
 require (
 	github.com/INFURA/go-ethlibs v0.0.0-20190906161005-7045fb26c40c
+	github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89
 	github.com/umbracle/go-web3 v0.0.0-20200107141429-b044b1dc2479
 )

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,7 @@ github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89 h1:12K8AlpT0/6QUXSfV0yi4Q0jkbq8NDtIKFtF61AoqV0=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=

--- a/main.go
+++ b/main.go
@@ -11,9 +11,18 @@ import (
 	"time"
 
 	"github.com/INFURA/go-ethlibs/node"
+	flags "github.com/jessevdk/go-flags"
 )
 
-var defaultWeb3Endpoint = "https://mainnet.infura.io/v3/af500e495f2d4e7cbcae36d0bfa66bcb" // Versus API key on Infura
+// Version of the binary, assigned during build.
+var Version = "dev"
+
+// Options contains the flag options
+type Options struct {
+	Web3Endpoint string `long:"rpc" description:"Ethereum JSONRPC provider, such as Infura or Cloudflare" default:"https://mainnet.infura.io/v3/af500e495f2d4e7cbcae36d0bfa66bcb"` // Versus API key on Infura
+
+	Version bool `long:"version" description:"Print version and exit."`
+}
 
 func exit(code int, format string, args ...interface{}) {
 	fmt.Fprintf(os.Stderr, format, args...)
@@ -21,13 +30,27 @@ func exit(code int, format string, args ...interface{}) {
 }
 
 func main() {
+	options := Options{}
+	p, err := flags.NewParser(&options, flags.Default).ParseArgs(os.Args[1:])
+	if err != nil {
+		if p == nil {
+			fmt.Println(err)
+		}
+		return
+	}
+
+	if options.Version {
+		fmt.Println(Version)
+		os.Exit(0)
+	}
+
 	gen := generator{}
 	installDefaults(&gen)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	client, err := node.NewClient(ctx, defaultWeb3Endpoint)
+	client, err := node.NewClient(ctx, options.Web3Endpoint)
 	if err != nil {
 		exit(1, "failed to make a new client: %s", err)
 	}


### PR DESCRIPTION
This commit make the RPC endpoint specifiable using `--rpc`.
Default provider is Infura.

Because there was no options before, the commit also add `--version` to
get the current version.