### PR TITLE
Add rate-limiter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/INFURA/go-ethlibs v0.0.0-20190906161005-7045fb26c40c
 	github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89
 	github.com/umbracle/go-web3 v0.0.0-20200107141429-b044b1dc2479
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 )

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/time v0.0.0-20191024005414-555d28b269f0 h1:/5xXl8Y5W96D+TtHSlonuFqGHIWVuyCkGJLwGh9JJFs=
+golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=

--- a/main.go
+++ b/main.go
@@ -77,6 +77,13 @@ func main() {
 		for {
 			newState, err := mkState.Refresh(&state)
 			if err != nil {
+				// It can happen in some testnets that most of the blocks
+				// are empty(no transaction included), don't refresh the
+				// generator state without new inclusion.
+				if err == errEmptyBlock {
+					time.Sleep(time.Second * 5)
+					continue
+				}
 				exit(2, "failed to refresh state")
 			}
 			select {

--- a/main.go
+++ b/main.go
@@ -81,7 +81,11 @@ func main() {
 				// are empty(no transaction included), don't refresh the
 				// generator state without new inclusion.
 				if err == errEmptyBlock {
-					time.Sleep(time.Second * 5)
+					select {
+					case <-time.After(5 * time.Second):
+					case <-ctx.Done():
+						return
+					}
 					continue
 				}
 				exit(2, "failed to refresh state")

--- a/state.go
+++ b/state.go
@@ -10,6 +10,8 @@ import (
 	"github.com/INFURA/go-ethlibs/node"
 )
 
+var errEmptyBlock = errors.New("the sampled block is empty")
+
 type State interface {
 	RandInt64() int64
 	ID() int64
@@ -130,7 +132,10 @@ func (p *stateProducer) Refresh(oldState *liveState) (*liveState, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	// Short circuit if the sampled block is empty
+	if len(b.Transactions) == 0 {
+		return nil, errEmptyBlock
+	}
 	// txs will grow to the maximum contract transaction list size we'll see in a block, and the higher-indexed ones will stick around longer
 	txs := oldState.transactions
 	for i, tx := range b.Transactions {


### PR DESCRIPTION
Hi @shazow, thanks for the great tool. Here is a PR for a few improvements.

First, it adds the rate limiter for request generation. The tool will generate RPC calls without any limitation by default. However, in some cases, the rate limiter can help a lot. E.g. generate some workload but not for benchmark.

Second, it fixes an issue when adding new clues from a real chain. Normally in some testnets, some blocks can be empty. It doesn't make sense to refresh the "generator state" without new clues added.
Especially the state is retrieved for the first time, it will lead to some invalid RPC generated.