### PR TITLE
queries: allow 0-weigth (ignore payload)

### DIFF
--- a/queries.go
+++ b/queries.go
@@ -116,6 +116,9 @@ func installDefaults(gen *generator, methods map[string]int64) error {
 	}
 
 	for method, weight := range methods {
+		if weight == 0 {
+			continue
+		}
 		if _, err := rpcMethod[method]; err == false {
 			return errors.New(method + " is not supported")
 		}


### PR DESCRIPTION
Without this fix: 
```
[user@work ethspam]$ go run . -m=eth_getCode:100 -m=eth_getLogs:0  -m=eth_getTransactionByHash:0  -m=eth_blockNumber:0  -m=eth_getTransactionCount:400 -m=eth_getBlockByNumber:0 -m=eth_getBalance:550  -m=eth_getTransactionReceipt:0  -m=eth_call:2000
panic: runtime error: slice bounds out of range [2:1]

goroutine 1 [running]:
main.(*generator).Add(0xc000055ed8, 0x7ffef9be0069, 0xf, 0x0, 0x9143d0)
        /home/user/go/src/github.com/shazow/ethspam/main.go:154 +0x343
main.installDefaults(0xc000055ed8, 0xc00002aea0, 0x9, 0x9)
        /home/user/go/src/github.com/shazow/ethspam/queries.go:122 +0x3ec
main.main()
        /home/user/go/src/github.com/shazow/ethspam/main.go:51 +0x19e
exit status 2

```
WIth this fix it works. 

